### PR TITLE
Don't rely on API-reported file size, but on HTTP response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2020.4
+
+- Don't rely on OpenNeuro API-reported file sizes anymore, but trust the
+  HTTP server. This will do away with error messages, and fix bugs when
+  downloading TSV and JSON files, which would sometimes end up being
+  incorrectly appended.
+
 ## 2020.3.1
 
 - Pin `httpx` requirement to `>=0.15`

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -47,7 +47,7 @@ def _get_download_metadata(*,
 
 def _download_file(*,
                    url: str,
-                   remote_file_size: int,
+                   api_file_size: int,
                    outfile: Path,
                    verify_hash: bool,
                    verify_size: bool,
@@ -60,8 +60,17 @@ def _download_file(*,
     else:
         local_file_size = 0
 
-    headers = {}
     # Check if we need to resume a download
+    # The file sizes provided via the API often do not match the sizes reported
+    # by the HTTP server. Rely on the sizes reported by the HTTP server.
+    with httpx.Client() as client:
+        response = client.get(url=url)
+        try:
+            remote_file_size = int(response.headers['content-length'])
+        except KeyError:
+            remote_file_size = len(response.content)
+
+    headers = {}
     if outfile.exists() and local_file_size == remote_file_size:
         # Download complete, skip.
         tqdm.write(f'Skipping {outfile.name}: already downloaded.')
@@ -134,12 +143,12 @@ def _download_files(*,
     """
     for file in files:
         filename = Path(file['filename'])
-        file_size = file['size']
+        api_file_size = file['size']
         url = file['urls'][0]
 
         outfile = target_dir / filename
         outfile.parent.mkdir(parents=True, exist_ok=True)
-        _download_file(url=url, remote_file_size=file_size, outfile=outfile,
+        _download_file(url=url, api_file_size=api_file_size, outfile=outfile,
                        verify_hash=verify_hash, verify_size=verify_size,
                        max_retries=max_retries, retry_backoff=retry_backoff)
 

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -68,6 +68,7 @@ def _download_file(*,
     try:
         remote_file_size = int(response.headers['content-length'])
     except KeyError:
+        # TSV and JSON files may not have a Content-Length header set.
         remote_file_size = len(response.content)
 
     headers = {}

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -65,10 +65,10 @@ def _download_file(*,
     # by the HTTP server. Rely on the sizes reported by the HTTP server.
     with httpx.Client() as client:
         response = client.get(url=url)
-        try:
-            remote_file_size = int(response.headers['content-length'])
-        except KeyError:
-            remote_file_size = len(response.content)
+    try:
+        remote_file_size = int(response.headers['content-length'])
+    except KeyError:
+        remote_file_size = len(response.content)
 
     headers = {}
     if outfile.exists() and local_file_size == remote_file_size:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openneuro-py
-version = 2020.3.1
+version = 2020.4
 author = Richard Höchenberger <richard.hoechenberger@gmail.com>
 author_email = richard.hoechenberger@gmail.com
 url = https://github.com/hoechenberger/openneuro-py


### PR DESCRIPTION
Also adds special handling for certain files (TSV, JSON) that will
not be streamed and for which the server doesn't report a Content-Length.
For these files, the data is entirely contained within the response
body.