### PR TITLE
[DOC] Clarified input type for input and output

### DIFF
--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -367,10 +367,10 @@ def download(*,
         create a subdirectory with the dataset name in the current working
         directory.
     include
-        A list of files and directories to download.
-        **Only** these files and directories will be retrieved.
+        Files and directories to download. **Only** these files and directories
+        will be retrieved.
     exclude
-        A list of files and directories to exclude from downloading.
+        Files and directories to exclude from downloading.
     verify_hash
         Whether to calculate and print the SHA256 hash of each downloaded file.
     verify_size
@@ -407,6 +407,8 @@ def download(*,
     else:
         target_dir = Path(target_dir)
 
+    include = [include] if isinstance(include, str) else include
+    exclude = [exclude] if isinstance(include, str) else exclude
     include = [] if include is None else list(include)
     exclude = [] if exclude is None else list(exclude)
 

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -367,10 +367,10 @@ def download(*,
         create a subdirectory with the dataset name in the current working
         directory.
     include
-        Files and directories to download. **Only** these files and directories
-        will be retrieved.
+        A list of files and directories to download.
+        **Only** these files and directories will be retrieved.
     exclude
-        Files and directories to exclude from downloading.
+        A list of files and directories to exclude from downloading.
     verify_hash
         Whether to calculate and print the SHA256 hash of each downloaded file.
     verify_size
@@ -388,7 +388,7 @@ def download(*,
     if stdout_unicode:
         msg_great_to_see_you += ' 🤗'
     msg_please = '👉 Please' if stdout_unicode else '   Please'
-        
+
     msg = (f'\n{msg_hello} This is openneuro-py {__version__}. '
            f'{msg_great_to_see_you}\n\n'
            f'   {msg_please} report {msg_problems} and {msg_bugs} at\n'


### PR DESCRIPTION
This is one solution to just add it to the text but, more broadly, the documentation could also be changed to include input types. That might help users avoid getting uninformative errors when, for instance, passing a string as an input to `on.download`.