### PR TITLE
Don't stream the HEAD response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2021.4
+
+- Avoid timeouts that would occur in certain situations.
+
 ## 2021.3
 
 - Add Unix path expansion for `openneuro.download()`.

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -94,7 +94,8 @@ def _check_snapshot_exists(*,
             request_timed_out = True
 
     if request_timed_out and max_retries > 0:
-        tqdm.write('Request timed out, retrying …')
+        tqdm.write('Request timed out while fetching list of snapshots, '
+                   'retrying …')
         asyncio.sleep(retry_backoff)
         max_retries -= 1
         retry_backoff *= 2
@@ -142,7 +143,7 @@ def _get_download_metadata(*,
             request_timed_out = True
 
     if request_timed_out and max_retries > 0:
-        tqdm.write('Request timed out, retrying …')
+        tqdm.write('Request timed out while fetching metadata, retrying …')
         asyncio.sleep(retry_backoff)
         max_retries -= 1
         retry_backoff *= 2
@@ -186,8 +187,8 @@ async def _download_file(*,
     async with semaphore:
         async with httpx.AsyncClient() as client:
             try:
-                async with client.stream('HEAD', url=url) as response:
-                    headers = response.headers
+                response = await client.head(url)
+                headers = response.headers
             except allowed_retry_exceptions:
                 if max_retries > 0:
                     await _retry_download(
@@ -331,7 +332,7 @@ async def _retry_download(
     retry_backoff: float,
     semaphore: asyncio.Semaphore
 ) -> None:
-    tqdm.write('Request timed out, retrying …')
+    tqdm.write('Request timed out while downloading, retrying …')
     await asyncio.sleep(retry_backoff)
     max_retries -= 1
     retry_backoff *= 2


### PR DESCRIPTION
This would try to download the entire content in some cases,
leading to a timeout.

Note that this will not resolve the concurrency issue we witnessed
at https://github.com/autoreject/autoreject/pull/209#issuecomment-842935106 