### PR TITLE
Disable transfer encoding (i.e., compression)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2021.6
+
+- Disable transfer encoding (i.e., compression). This allows for an easier
+  check whether a file has been completely downloaded.
+
 ## 2021.5
 
 - Ramp up timeouts from 5 to 30 seconds for downloads from `openneuro.org`.

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -252,6 +252,8 @@ async def _download_file(*,
                                            f'{outfile}.')
 
     headers = {}
+    headers['Accept-Encoding'] = ''  # Disable compression
+
     if outfile.exists() and local_file_size == remote_file_size:
         hash = hashlib.md5()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openneuro-py
-version = 2021.5
+version = 2021.6
 author = Richard Höchenberger <richard.hoechenberger@gmail.com>
 author_email = richard.hoechenberger@gmail.com
 url = https://github.com/hoechenberger/openneuro-py


### PR DESCRIPTION
This allows for an easier check whether a file has been
completely downloaded.