### PR TITLE
Don't download  file(s) just to determine size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,15 @@
 - Before resuming a download, check if local and remote datasets actually
   match.
 
+- If neither the API nor the HTTP server provide the file size, don't download
+  the file just for size determination. This won't allow us to display progress
+  bars anymore in this case, but it will avoid downloading the same file twice.
+  Unfortunately, resuming such downloads will be impossible, too: we'll simply
+  re-download the files. Note that this only applies to files hosted on
+  OpenNeuro.org for which we cannot determine the file size.
+
+- Massively reduce memory footprint (by 2 orders of magnitude).
+
 ## 2021.6
 
 - Disable transfer encoding (i.e., compression). This allows for an easier

--- a/openneuro/openneuro.py
+++ b/openneuro/openneuro.py
@@ -1,5 +1,5 @@
 """
-openneuro-py is a leightweight client for accessing OpenNeuro datasets.
+openneuro-py is a lightweight client for accessing OpenNeuro datasets.
 
 Created and maintained by
 Richard Höchenberger <richard.hoechenberger@gmail.com>


### PR DESCRIPTION
If neither the API nor the HTTP server provide the file size, don't download the file just for size determination. This won't allow us to display progress bars anymore in this case, but it will avoid downloading the same file twice. Unfortunately, resuming such downloads will be impossible, too: we'll simply re-download the files. Note that this only applies to files hosted on OpenNeuro.org for which we cannot determine the file size.

This PR also massively reduces memory footprint (by 2 orders of magnitude):

`main`:
<img width="600" alt="Screen Shot 2021-05-23 at 20 37 42" src="https://user-images.githubusercontent.com/2046265/119275908-1f949400-bc18-11eb-808e-4a23271468ce.png">

this PR:
<img width="600" alt="Screen Shot 2021-05-23 at 22 01 17" src="https://user-images.githubusercontent.com/2046265/119275917-26bba200-bc18-11eb-81b0-a842b17c4d44.png">

x-ref https://github.com/autoreject/autoreject/pull/209