### PR TITLE
Don't crash if local dataset_description.json is empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 - Add basic support for running Jupyter Notebooks / Jupyter Lab, interactive
   IPython sessions, and in the VS Code interactive Jupyter window.
 
+- Don't crash if the local `dataset_description.json` file is empty when trying
+  to resume an aborted download.
+
 ## 2021.8
 
 - Retry downloads if a `ReadError` has occurred.

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -475,8 +475,11 @@ def _get_local_tag(
     if not local_json_path.exists():
         return None
 
-    with local_json_path.open('r', encoding='utf-8') as f:
-        local_json = json.load(f)
+    local_json_file_content = local_json_path.read_text(encoding='utf-8')
+    if not local_json_file_content:
+        return None
+
+    local_json = json.loads(local_json_file_content)
 
     if 'DatasetDOI' not in local_json:
         raise RuntimeError('Local "dataset_description.json" does not contain '


### PR DESCRIPTION
Don't crash if the local `dataset_description.json` file is empty when trying to resume an aborted download.
