### PR TITLE
Add openneuro-py login command to enable authentication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
   entries.
 - Drop list of default excludes. OpenNeuro has fixed server response for the
   respective datasets, so excluding files by default is not necessary anymore.
+- Add ability to use an API token to access restricted datasets.
 
 ## 2022.1.0
 

--- a/README.md
+++ b/README.md
@@ -94,3 +94,14 @@ openneuro-py download --dataset=ds000246 \
                       --include=sub-0001/meg/sub-0001_coordsystem.json \
                       --include=sub-0001/meg/sub-0001_acq-LPA_photo.jpg
 ```
+
+### Use an API token to log in
+
+To download private datasets, you will need an API key that grants you access
+permissions. Go to OpenNeuro.org, My Account → Obtain an API Key. Copy the key,
+and run:
+
+```shell
+openneuro-py login
+```
+Paste the API key and press return.

--- a/openneuro/__init__.py
+++ b/openneuro/__init__.py
@@ -10,4 +10,4 @@ except metadata.PackageNotFoundError:
     # package is not installed
     pass
 
-from .download import download  # noqa: F401
+from ._download import download, login  # noqa: F401

--- a/openneuro/_download.py
+++ b/openneuro/_download.py
@@ -33,7 +33,7 @@ import aiofiles
 from sgqlc.endpoint.requests import RequestsEndpoint
 
 from . import __version__
-from .config import default_base_url, get_token
+from .config import BASE_URL, get_token, init_config
 
 
 if hasattr(sys.stdout, 'encoding') and sys.stdout.encoding.lower() == 'utf-8':
@@ -43,6 +43,11 @@ elif hasattr(sys.stdout, 'reconfigure'):
     stdout_unicode = True
 else:
     stdout_unicode = False
+
+
+def login():
+    """Login to OpenNeuro and store an access token."""
+    init_config()
 
 
 # HTTP server responses that indicate hopefully intermittent errors that
@@ -162,7 +167,7 @@ def _check_snapshot_exists(*,
 
 
 def _get_download_metadata(*,
-                           base_url: str = default_base_url,
+                           base_url: str = BASE_URL,
                            dataset_id: str,
                            tag: Optional[str] = None,
                            tree: str = 'null',

--- a/openneuro/config.py
+++ b/openneuro/config.py
@@ -28,7 +28,7 @@ def init_config() -> None:
     tqdm.write('🙏 Please login to your OpenNeuro account and go to: '
                'My Account → Obtain an API Key')
     api_key = getpass.getpass('OpenNeuro API key (input hidden): ')
-    
+
     config = Config(
         endpoint=BASE_URL,
         apikey=api_key,

--- a/openneuro/config.py
+++ b/openneuro/config.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import stat
 import json
 import getpass
 
@@ -26,6 +27,7 @@ def init_config() -> None:
                   errorReporting=False)
     with open(config_fname, 'w', encoding='utf-8') as f:
         json.dump(config, f)
+    os.chmod(config_fname, stat.S_IRUSR)
 
 
 def load_config() -> dict:

--- a/openneuro/config.py
+++ b/openneuro/config.py
@@ -43,8 +43,7 @@ def get_token() -> str:
 
     Returns
     -------
-    str
-        The API token if configured.
+    The API token if configured.
 
     Raises
     ------

--- a/openneuro/config.py
+++ b/openneuro/config.py
@@ -1,9 +1,13 @@
-from typing import TypedDict
 from pathlib import Path
 import os
+import sys
 import stat
 import json
 import getpass
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 import appdirs
 from tqdm.auto import tqdm
@@ -29,10 +33,10 @@ def init_config() -> None:
                'My Account → Obtain an API Key')
     api_key = getpass.getpass('OpenNeuro API key (input hidden): ')
 
-    config = Config(
-        endpoint=BASE_URL,
-        apikey=api_key,
-    )
+    config: Config = {
+        'endpoint': BASE_URL,
+        'apikey': api_key,
+    }
 
     with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
         json.dump(config, f, indent=2)

--- a/openneuro/config.py
+++ b/openneuro/config.py
@@ -1,14 +1,25 @@
+from typing import TypedDict
 from pathlib import Path
 import os
 import stat
 import json
 import getpass
 
+import appdirs
 from tqdm.auto import tqdm
 
 
-config_fname = Path('~/.openneuro').expanduser()
-default_base_url = 'https://openneuro.org/'
+CONFIG_DIR = Path(
+    appdirs.user_config_dir(appname='openneuro-py', appauthor=False, roaming=True)
+)
+CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+CONFIG_PATH = CONFIG_DIR / 'config.json'
+BASE_URL = 'https://openneuro.org/'
+
+
+class Config(TypedDict):
+    endpoint: str
+    apikey: str
 
 
 def init_config() -> None:
@@ -17,12 +28,15 @@ def init_config() -> None:
     tqdm.write('🙏 Please login to your OpenNeuro account and go to: '
                'My Account → Obtain an API Key')
     api_key = getpass.getpass('OpenNeuro API key (input hidden): ')
-    config = dict(url=default_base_url,
-                  apikey=api_key,
-                  errorReporting=False)
-    with open(config_fname, 'w', encoding='utf-8') as f:
-        json.dump(config, f)
-    os.chmod(config_fname, stat.S_IRUSR)
+    
+    config = Config(
+        endpoint=BASE_URL,
+        apikey=api_key,
+    )
+
+    with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
+        json.dump(config, f, indent=2)
+    os.chmod(CONFIG_PATH, stat.S_IRUSR | stat.S_IWUSR)
 
 
 def load_config() -> dict:
@@ -33,7 +47,7 @@ def load_config() -> dict:
     dict
         The configuration options.
     """
-    with open(config_fname, 'r', encoding='utf-8') as f:
+    with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
         config = json.load(f)
     return config
 
@@ -50,12 +64,14 @@ def get_token() -> str:
     ValueError
         When no token has been configured yet.
     """
-    if not config_fname.exists():
-        raise ValueError('Could not read API token as no ~/.openneuro config '
-                         'file exists. Run "openneuro login" to generate it.')
+    if not CONFIG_PATH.exists():
+        raise ValueError(
+            'Could not read API token as no openneuro-py configuration '
+            'file exists. Run "openneuro login" to generate it.'
+        )
     config = load_config()
     if 'apikey' not in config:
-        raise ValueError('An ~/.openneuro config file was found, but did not '
+        raise ValueError('An openneuro-py configuration file was found, but did not '
                          'contain an "apikey" entry. Run "openneuro login" to '
                          'add such an entry.')
     return config['apikey']

--- a/openneuro/config.py
+++ b/openneuro/config.py
@@ -1,6 +1,14 @@
 from pathlib import Path
+import os
 import json
 import getpass
+
+# Manually "enforce" notebook mode in VS Code to get progress bar widgets
+# Can be removed once https://github.com/tqdm/tqdm/issues/1213 has been merged
+if 'VSCODE_PID' in os.environ:
+    from tqdm.notebook import tqdm
+else:
+    from tqdm.auto import tqdm
 
 
 config_fname = Path('~/.openneuro').expanduser()
@@ -10,6 +18,8 @@ default_base_url = 'https://openneuro.org/'
 def init_config() -> None:
     """Initialize a new OpenNeuro configuration file.
     """
+    tqdm.write('🙏 Please login to your OpenNeuro account and go to: '
+               'My Account → Obtain an API Key')
     api_key = getpass.getpass('OpenNeuro API key (input hidden): ')
     config = dict(url=default_base_url,
                   apikey=api_key,
@@ -29,3 +39,27 @@ def load_config() -> dict:
     with open(config_fname, 'r', encoding='utf-8') as f:
         config = json.load(f)
     return config
+
+
+def get_token() -> str:
+    """Get the OpenNeuro API token if configured with the 'login' command.
+
+    Returns
+    -------
+    str
+        The API token if configured.
+
+    Raises
+    ------
+    ValueError
+        When no token has been configured yet.
+    """
+    if not config_fname.exists():
+        raise ValueError('Could not read API token as no ~/.openneuro config '
+                         'file exists. Run "openneuro login" to generate it.')
+    config = load_config()
+    if 'apikey' not in config:
+        raise ValueError('An ~/.openneuro config file was found, but did not '
+                         'contain an "apikey" entry. Run "openneuro login" to '
+                         'add such an entry.')
+    return config['apikey']

--- a/openneuro/config.py
+++ b/openneuro/config.py
@@ -4,12 +4,7 @@ import stat
 import json
 import getpass
 
-# Manually "enforce" notebook mode in VS Code to get progress bar widgets
-# Can be removed once https://github.com/tqdm/tqdm/issues/1213 has been merged
-if 'VSCODE_PID' in os.environ:
-    from tqdm.notebook import tqdm
-else:
-    from tqdm.auto import tqdm
+from tqdm.auto import tqdm
 
 
 config_fname = Path('~/.openneuro').expanduser()

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -202,11 +202,15 @@ def _get_download_metadata(*,
         if 'errors' in response_json:
             msg = response_json["errors"][0]["message"]
             if msg == 'You do not have access to read this dataset.':
-                raise RuntimeError('It seems you do not have access to this '
-                                   'dataset. If this is a restricted dataset, '
-                                   'please use the "openneuro-py login" '
-                                   'command to configure an API token for '
-                                   'authentication.')
+                try:
+                    get_token()
+                    raise RuntimeError('It seems you do not have access to '
+                                       'this dataset.')
+                except ValueError as e:
+                    # No token configured
+                    raise RuntimeError('It seems you do not have access to '
+                                       'this dataset and authentication '
+                                       f'failed. {e}')
             else:
                 raise RuntimeError(f'Query failed: "{msg}"')
         elif tag is None:

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -203,14 +203,18 @@ def _get_download_metadata(*,
             msg = response_json["errors"][0]["message"]
             if msg == 'You do not have access to read this dataset.':
                 try:
+                    # Do we have an API token?
                     get_token()
-                    raise RuntimeError('It seems you do not have access to '
-                                       'this dataset.')
+                    raise RuntimeError('We were not permitted to download '
+                                       'this dataset. Perhaps your user '
+                                       'does not have access to it, or '
+                                       'your API token is wrong.')
                 except ValueError as e:
-                    # No token configured
-                    raise RuntimeError('It seems you do not have access to '
-                                       'this dataset and authentication '
-                                       f'failed. {e}')
+                    # We don't have an API token.
+                    raise RuntimeError('It seems that this is a restricted '
+                                       'dataset. However, your API token is '
+                                       'not configured properly, so we could '
+                                       f'not log you in. {e}')
             else:
                 raise RuntimeError(f'Query failed: "{msg}"')
         elif tag is None:

--- a/openneuro/openneuro.py
+++ b/openneuro/openneuro.py
@@ -7,8 +7,7 @@ Richard Höchenberger <richard.hoechenberger@gmail.com>
 
 import click
 
-from .download import download_cli
-from .config import init_config
+from ._download import login, download_cli
 from . import __version__
 
 
@@ -21,9 +20,9 @@ def cli() -> None:
 
 
 @click.command()
-def login_cli(**kwargs):
-    """Login to Open Neuro and write the ~/.openneuro config file."""
-    init_config()
+def login_cli():
+    """Login to OpenNeuro and store an access token."""
+    login()
 
 
 cli.add_command(download_cli, name='download')

--- a/openneuro/openneuro.py
+++ b/openneuro/openneuro.py
@@ -8,6 +8,7 @@ Richard Höchenberger <richard.hoechenberger@gmail.com>
 import click
 
 from .download import download_cli
+from .config import init_config
 from . import __version__
 
 
@@ -19,4 +20,11 @@ def cli() -> None:
     pass
 
 
+@click.command()
+def login_cli(**kwargs):
+    """Login to Open Neuro and write the ~/.openneuro config file."""
+    init_config()
+
+
 cli.add_command(download_cli, name='download')
+cli.add_command(login_cli, name='login')

--- a/openneuro/tests/test_config.py
+++ b/openneuro/tests/test_config.py
@@ -13,7 +13,7 @@ def test_config(tmp_path: Path):
         with mock.patch('getpass.getpass', lambda _: 'test'):
             init_config()
         assert openneuro.config.CONFIG_PATH.exists()
-        
+
         expected_config = Config(endpoint='https://openneuro.org/', apikey='test')
         assert load_config() == expected_config
         assert get_token() == 'test'

--- a/openneuro/tests/test_config.py
+++ b/openneuro/tests/test_config.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from unittest import mock
+
+import openneuro
+from openneuro.config import init_config, load_config, get_token
+
+
+def test_config(tmp_path: Path):
+    """Test creating and reading the config file."""
+    openneuro.config.config_fname = tmp_path / '.openneuro'
+    with mock.patch('getpass.getpass', lambda _: 'test'):
+        init_config()
+    assert openneuro.config.config_fname.exists()
+    assert load_config() == {'apikey': 'test', 'errorReporting': False,
+                             'url': 'https://openneuro.org/'}
+    assert get_token() == 'test'

--- a/openneuro/tests/test_config.py
+++ b/openneuro/tests/test_config.py
@@ -2,15 +2,18 @@ from pathlib import Path
 from unittest import mock
 
 import openneuro
-from openneuro.config import init_config, load_config, get_token
+from openneuro.config import init_config, load_config, get_token, Config
 
 
 def test_config(tmp_path: Path):
     """Test creating and reading the config file."""
-    openneuro.config.config_fname = tmp_path / '.openneuro'
-    with mock.patch('getpass.getpass', lambda _: 'test'):
-        init_config()
-    assert openneuro.config.config_fname.exists()
-    assert load_config() == {'apikey': 'test', 'errorReporting': False,
-                             'url': 'https://openneuro.org/'}
-    assert get_token() == 'test'
+    with mock.patch.object(openneuro.config, 'CONFIG_PATH', tmp_path / '.openneuro'):
+        assert not openneuro.config.CONFIG_PATH.exists()
+
+        with mock.patch('getpass.getpass', lambda _: 'test'):
+            init_config()
+        assert openneuro.config.CONFIG_PATH.exists()
+        
+        expected_config = Config(endpoint='https://openneuro.org/', apikey='test')
+        assert load_config() == expected_config
+        assert get_token() == 'test'

--- a/openneuro/tests/test_download.py
+++ b/openneuro/tests/test_download.py
@@ -2,6 +2,8 @@ import json
 from pathlib import Path
 
 import pytest
+from unittest import mock
+import openneuro
 from openneuro import download
 
 
@@ -118,3 +120,17 @@ def test_doi_handling(tmp_path: Path):
         include=['participants.tsv'],
         target_dir=tmp_path
     )
+
+
+def test_restricted_dataset(tmp_path: Path):
+    """Test downloading a restricted dataset."""
+    # API token for dummy user alijflsdvbjielsdlkjfeiljsvj@gmail.com
+    token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxOGNhNjE2ZS00OWQxLTRmOTUtODI1OS0xNzYwYzVhYjZjMDciLCJlbWFpbCI6ImFsaWpmbHNkdmJqaWVsc2Rsa2pmZWlsanN2akBnbWFpbC5jb20iLCJwcm92aWRlciI6Imdvb2dsZSIsIm5hbWUiOiJzZGZrbGVpamZsa3NkamYgc2xmZGRsa2phYWlmbCIsImFkbWluIjpmYWxzZSwiaWF0IjoxNjY1NDY4MjM4LCJleHAiOjE2OTcwMDQyMzh9.7YVL_Cagli84nTmumdcmrV1bW5hZMq3VJlMUDmTEpGU'  # noqa
+    openneuro.config.config_fname = tmp_path / '.openneuro'
+    with mock.patch('getpass.getpass', lambda _: token):
+        openneuro.config.init_config()
+
+        # This is a restricted dataset that is only available if the API token
+        # was used correctly.
+        download(dataset='ds004287', target_dir=tmp_path)
+    assert (tmp_path / 'README').exists()

--- a/openneuro/tests/test_download.py
+++ b/openneuro/tests/test_download.py
@@ -138,11 +138,13 @@ def test_restricted_dataset(tmp_path: Path):
     """Test downloading a restricted dataset."""
     # API token for dummy user alijflsdvbjielsdlkjfeiljsvj@gmail.com
     token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxOGNhNjE2ZS00OWQxLTRmOTUtODI1OS0xNzYwYzVhYjZjMDciLCJlbWFpbCI6ImFsaWpmbHNkdmJqaWVsc2Rsa2pmZWlsanN2akBnbWFpbC5jb20iLCJwcm92aWRlciI6Imdvb2dsZSIsIm5hbWUiOiJzZGZrbGVpamZsa3NkamYgc2xmZGRsa2phYWlmbCIsImFkbWluIjpmYWxzZSwiaWF0IjoxNjY1NDY4MjM4LCJleHAiOjE2OTcwMDQyMzh9.7YVL_Cagli84nTmumdcmrV1bW5hZMq3VJlMUDmTEpGU'  # noqa
-    openneuro.config.config_fname = tmp_path / '.openneuro'
-    with mock.patch('getpass.getpass', lambda _: token):
-        openneuro.config.init_config()
+
+    with mock.patch.object(openneuro.config, 'CONFIG_PATH', tmp_path / '.openneuro'):
+        with mock.patch('getpass.getpass', lambda _: token):
+            openneuro.config.init_config()
 
         # This is a restricted dataset that is only available if the API token
         # was used correctly.
         download(dataset='ds004287', target_dir=tmp_path)
+
     assert (tmp_path / 'README').exists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "aiofiles",
     "sgqlc",
     "importlib-metadata; python_version < '3.8'",
-    "typing-extensions; python_version < '3.8'"
+    "typing-extensions; python_version < '3.8'",
+    "appdirs",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
To download restricted datasets, we need to authenticate ourselves using an API token. This PR adds a new command `openneuro login` to write the API token to the `~/.openneuro` config file. The `openneuro-py download` command has been modified to send the token along as a cookie.

fixes #60 