### PR TITLE
MAINT: Update for latest API

### DIFF
--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -647,7 +647,7 @@ def download(*,
                                        dataset_dir=target_dir)
 
             if local_tag is None:
-                tqdm.write('Cannot determine local revision of the dataset ,'
+                tqdm.write('Cannot determine local revision of the dataset, '
                            'and the target directory is not empty. If the '
                            'download fails, you may want to try again with a '
                            'fresh (empty) target directory.')

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -516,7 +516,12 @@ def _get_local_tag(
     return local_version
 
 
-def _unicode(msg, *, emoji=' ', end='…'):
+def _unicode(
+    msg: str,
+    *,
+    emoji: str = ' ',
+    end: str = '…'
+) -> str:
     if stdout_unicode:
         msg = f'{emoji} {msg} {end}'
     elif end == '…':

--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -713,7 +713,6 @@ def download(*,
             # Keep track of include matches.
             if any(matches_keep):
                 include_counts[matches_keep.index(True)] += 1
-    raise RuntimeError
 
     if include:
         for idx, count in enumerate(include_counts):


### PR DESCRIPTION
Locally I get something that seems to work:
```
$ python -ui mne_bids_pipeline/tests/run_tests.py --download=1 ds000248
...
🌍 Preparing to download ds000248 …
📁 Traversing directory structure for ds000248 (this can take a while) …
    derivatives 
    │ derivatives/freesurfer 
    │ │ derivatives/freesurfer/subjects 
    │ │ │ derivatives/freesurfer/subjects/fsaverage 
    │ │ │ │ derivatives/freesurfer/subjects/fsaverage/bem 
    │ │ │ │ derivatives/freesurfer/subjects/fsaverage/label 
    │ │ │ │ derivatives/freesurfer/subjects/fsaverage/mri 
    │ │ │ │ │ derivatives/freesurfer/subjects/fsaverage/mri/transforms 
    │ │ │ │ derivatives/freesurfer/subjects/fsaverage/mri.2mm 
    │ │ │ │ derivatives/freesurfer/subjects/fsaverage/scripts 
    │ │ │ │ derivatives/freesurfer/subjects/fsaverage/surf 
    │ │ │ │ derivatives/freesurfer/subjects/fsaverage/xhemi 
    │ │ │ │ │ derivatives/freesurfer/subjects/fsaverage/xhemi/label 
    │ │ │ │ │ derivatives/freesurfer/subjects/fsaverage/xhemi/mri 
    │ │ │ │ │ │ derivatives/freesurfer/subjects/fsaverage/xhemi/mri/transforms 
    │ │ │ │ │ derivatives/freesurfer/subjects/fsaverage/xhemi/scripts 
    │ │ │ │ │ derivatives/freesurfer/subjects/fsaverage/xhemi/surf 
    │ │ │ │ │ derivatives/freesurfer/subjects/fsaverage/xhemi/touch 
    │ │ │ derivatives/freesurfer/subjects/morph-maps 
    │ │ │ derivatives/freesurfer/subjects/sub-01 
    │ │ │ │ derivatives/freesurfer/subjects/sub-01/bem 
    │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/bem/flash 
    │ │ │ │ derivatives/freesurfer/subjects/sub-01/label 
    │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri 
    │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri/T1 
    │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri/brain 
    │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri/flash 
    │ │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri/flash/parameter_maps 
    │ │ │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri/flash/parameter_maps/fsl_rigid_register.10366 
    │ │ │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri/flash/parameter_maps/fsl_rigid_register.14439 
    │ │ │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri/flash/parameter_maps/fsl_rigid_register.15197 
    │ │ │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri/flash/parameter_maps/fsl_rigid_register.9149 
    │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri/orig 
    │ │ │ │ │ derivatives/freesurfer/subjects/sub-01/mri/transforms 
    │ │ │ │ derivatives/freesurfer/subjects/sub-01/scripts 
    │ │ │ │ derivatives/freesurfer/subjects/sub-01/stats 
    │ │ │ │ derivatives/freesurfer/subjects/sub-01/surf 
    │ │ │ │ derivatives/freesurfer/subjects/sub-01/touch 
    sub-01 
    │ sub-01/anat 
    │ sub-01/meg 
    sub-emptyroom 
    │ sub-emptyroom/ses-19210819 
    │ │ sub-emptyroom/ses-19210819/meg 
📥 Retrieving up to 1220 files (5 concurrent downloads). 
✅ Finished downloading ds000248.                                                                                                                                                   
                                                                                             
🧠 Please enjoy your brains.  
```
I've tried it half a dozen times and so far no retry limit problem on the traversal. So I think we can leave it for future work to combine the filename traversal (which uses a generator/yield already) with file download queuing.

@hoechenberger feel free to try and merge if you're happy. I'm going to tell MNE-BIDS-Pipeline to use this branch in an upcoming PR, too, so we'll get some feedback there.

Closes #64
Closes #73