### PR TITLE
FIX: Only traverse necessary directories

### DIFF
--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -4,7 +4,7 @@ import fnmatch
 from difflib import get_close_matches
 import hashlib
 import asyncio
-from pathlib import Path
+from pathlib import Path, PosixPath
 import string
 import json
 from typing import Optional, Union
@@ -544,7 +544,8 @@ def _iterate_filenames(
     dataset_id: str,
     tag: str,
     max_retries: int,
-    root: str = ''
+    root: str = '',
+    include: Iterable[str] = tuple(),
 ) -> Generator[dict, None, None]:
     """Iterate over all files in a dataset, yielding filenames."""
     directories = list()
@@ -557,6 +558,37 @@ def _iterate_filenames(
             yield entity
 
     for directory in directories:
+        # Only bother with directories that are in the include list
+        if include:
+            # Take the example:
+            #
+            # --include="sub-CON001/*.eeg"
+            #
+            # or
+            #
+            # --include="sub-CON001"
+            #
+            # or
+            #
+            # --include="sub-CON001/*"
+            #
+            # All three of these should traverse `sub-CON001` and its
+            # subdirectories.
+            n_parts = len(PosixPath(root).parts)
+            dir_include = [PosixPath(inc) for inc in include]
+            dir_include = [  # for stuff like sub-CON001/*
+                '/'.join(inc.parts[:n_parts] + ('*',))
+                for inc in dir_include
+                if len(inc.parts) >= n_parts
+            ] + [  # and stuff like sub-CON001/*.eeg
+                '/'.join(inc.parts[:n_parts - 1] + ('*',))
+                for inc in dir_include
+                if len(inc.parts) >= n_parts - 1 and len(inc.parts) > 1
+            ]  # we want to traverse sub-CON001 in both cases
+            matches_include, _ = _match_include_exclude(
+                directory['filename'], include=dir_include, exclude=[])
+            if dir_include and not any(matches_include):
+                continue
         # Query filenames
         this_dir = directory['filename']
         metadata = _get_download_metadata(
@@ -572,9 +604,25 @@ def _iterate_filenames(
             tag=tag,
             max_retries=max_retries,
             root=this_dir,
+            include=include,
         )
         for path in dir_iterator:
             yield path
+
+
+def _match_include_exclude(
+    filename: str,
+    *,
+    include: Iterable[str],
+    exclude: Iterable[str],
+) -> bool:
+    """Check if a filename matches an include or exclude pattern."""
+    matches_keep = [filename.startswith(i) or fnmatch.fnmatch(filename, i)
+                    for i in include]
+    matches_remove = [filename.startswith(e) or
+                      fnmatch.fnmatch(filename, e)
+                      for e in exclude]
+    return matches_keep, matches_remove
 
 
 def download(*,
@@ -681,7 +729,8 @@ def download(*,
 
     for file in tqdm(
         _iterate_filenames(
-            these_files, dataset_id=dataset, tag=tag, max_retries=max_retries
+            these_files, dataset_id=dataset, tag=tag, max_retries=max_retries,
+            include=include,
         ),
         desc=_unicode(
             f'Traversing directories for {dataset}', end='', emoji='📁'
@@ -703,12 +752,9 @@ def download(*,
                 include_counts[include.index(filename)] += 1
             continue
 
-        matches_keep = [filename.startswith(i) or fnmatch.fnmatch(filename, i)
-                        for i in include]
-        matches_remove = [filename.startswith(e) or
-                          fnmatch.fnmatch(filename, e)
-                          for e in exclude]
-        if (not include or any(matches_keep)) and not any(matches_remove):
+        matches_keep, matches_exclude = _match_include_exclude(
+            filename, include=include, exclude=exclude)
+        if (not include or any(matches_keep)) and not any(matches_exclude):
             files.append(file)
             # Keep track of include matches.
             if any(matches_keep):
@@ -727,7 +773,7 @@ def download(*,
                 else:
                     extra = (
                         'There were no similar filenames found in the '
-                        'metadata.'
+                        'metadata. '
                     )
                 raise RuntimeError(
                     f'Could not find path in the dataset:\n- {this}\n{extra}'


### PR DESCRIPTION
I have been trying to download https://openneuro.org/datasets/ds004024/, and traversing the directory structure takes over a minute locally (!) for example for:
```
openneuro-py download --dataset=ds004024 --target_dir=$PWD --include="sub-CON001/*.eeg" --include="sub-CON001/*.tsv"
```
or
```
openneuro-py download --dataset=ds004024 --target_dir=$PWD --include="sub-CON001"
```
With these changes, either of these requires less than 10 seconds to traverse, because they are smart enough to ignore all other `sub-*` directories.

I'm not 100% sure the logic here is correct, but I do think we want something like this eventually to make `openneuro-py` more usable.