### PR TITLE
ENH: Better error code check

### DIFF
--- a/openneuro/download.py
+++ b/openneuro/download.py
@@ -178,9 +178,9 @@ def _get_download_metadata(*,
     response_json, request_timed_out = _safe_query(query, timeout=60)
 
     # Sometimes we do get a response, but it contains a gateway timeout error
-    # message (504 status code)
+    # message (504 or 502 status code)
     if (response_json is not None and 'errors' in response_json and
-            response_json['errors'][0]['message'].startswith('504')):
+            response_json['errors'][0]['message'].startswith(('504', '502'))):
         request_timed_out = True
 
     if request_timed_out and max_retries > 0:


### PR DESCRIPTION
I *think* this will help with this error:

https://app.circleci.com/pipelines/github/mne-tools/mne-bids-pipeline/3500/workflows/ef59c338-ff37-4295-a0c5-b2bb17c7bf32/jobs/40716

```
  File "/home/circleci/python_env/lib/python3.10/site-packages/openneuro/download.py", line 206, in _get_download_metadata
    raise RuntimeError(f'Query failed: '
RuntimeError: Query failed: "502 Server Error: Bad Gateway for url: https://openneuro.org/crn/graphql"
```

Because the error code is 502 (bad gateway), not 504 (gateway timeout), I think it's maybe not being caught properly?