### PR TITLE
Send User-Agent header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Set 'User-Agent' header to `openneuro-py/<version>`.
+
 ## 2023.1.0
 
 - Better handling of server response errors.


### PR DESCRIPTION
This adds a user-agent to both the requests session used for GraphQL queries and the httpx client used for file downloading.

Closes #123.