### PR TITLE
Don't display default parameter values for some parameters where showing them doesn't make much sense because they're `None`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v0.2.1
     hooks:
       - id: ruff
-        name: ruff lint
+        name: ruff (lint)
         args: ["--fix"]
       - id: ruff-format
-        name: ruff format
+        name: ruff (format)

--- a/README.md
+++ b/README.md
@@ -7,15 +7,10 @@ datasets.
 
 ## Installation
 
-### via conda
-
 ```shell
+# via conda:
 conda install -c conda-forge openneuro-py
-```
-
-### via pip
-
-```shell
+# or via pip:
 pip install openneuro-py
 ```
 
@@ -25,26 +20,22 @@ To get basic support for Jupyter Lab, Jupyter Notebook, IPython interactive
 sessions, and VS Code's interactive Jupyter interface, you will also need to
 install `ipywidgets`:
 
-### via conda
-
 ```shell
+# via conda:
 conda install -c conda-forge ipywidgets
-```
-
-### via pip
-
-```shell
+# or via pip:
 pip install ipywidgets
 ```
 
-## Basic usage – Python interface
-
-```python
-import openneuro as on
-on.download(dataset='ds000246', target_dir='data/bids')
-```
-
 ## Basic usage – command line interface
+
+### Getting help
+
+```shell
+openneuro-py --help
+openneuro-py download --help
+openneuro-py login --help
+```
 
 ### Download an entire dataset
 
@@ -69,6 +60,7 @@ Interrupted downloads will resume where they left off when you run the command
 again.
 
 ## Advanced usage – command line interface
+
 ### Exclude a directory from the download
 
 ```shell
@@ -104,4 +96,12 @@ and run:
 ```shell
 openneuro-py login
 ```
+
 Paste the API key and press return.
+
+## Basic usage – Python interface
+
+```python
+import openneuro as on
+on.download(dataset='ds000246', target_dir='data/bids')
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ openneuro-py = "openneuro._cli:app"
 
 [project.urls]
 homepage = "https://github.com/hoechenberger/openneuro-py"
-changelog = "https://github.com/hoechenberger/openneuro-py/CHANGES.md"
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,6 @@ select = ["E", "F", "W", "D", "I"]
 ignore = [
     "D100", # Missing docstring in public module
     "D104", # Missing docstring in public package
+    "D203", # One blank line before class
+    "D213", # Multi-line sumnmary second line
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ packages = ["src/openneuro"]
 [tool.pytest.ini_options]
 addopts = "-ra -vv --tb=short --durations=10"
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["E", "F", "W", "D", "I"]
 ignore = [
     "D100", # Missing docstring in public module

--- a/src/openneuro/_cli.py
+++ b/src/openneuro/_cli.py
@@ -10,44 +10,61 @@ app = typer.Typer(no_args_is_help=True)
 
 @app.command(name="download")
 def download_cli(
-    dataset: Annotated[str, typer.Option(help="The OpenNeuro dataset identifier.")],
+    dataset: Annotated[
+        str, typer.Option(help="The OpenNeuro dataset identifier.", show_default=False)
+    ],
     tag: Annotated[
-        Optional[str], typer.Option(help="The tag (version) of the dataset.")
+        Optional[str],
+        typer.Option(help="The tag (version) of the dataset.", show_default=False),
     ] = None,
     target_dir: Annotated[
-        Optional[str], typer.Option(help="The directory to download to.")
+        Optional[str],
+        typer.Option(
+            "--target_dir", help="The directory to download to.", show_default=False
+        ),
     ] = None,
     include: Annotated[
         Optional[str],
         typer.Option(
             help="Only include the specified file or directory. "
-            "Can be passed multiple times."
+            "Can be passed multiple times.",
+            show_default=False,
         ),
     ] = None,
     exclude: Annotated[
         Optional[str],
         typer.Option(
             help="Exclude the specified file or directory. "
-            "Can be passed multiple times."
+            "Can be passed multiple times.",
+            show_default=False,
         ),
     ] = None,
     verify_hash: Annotated[
         bool,
-        typer.Option(help="Whether to check the SHA256 hash of each downloaded file."),
+        typer.Option(
+            "--verify_hash",
+            help="Whether to check the SHA256 hash of each downloaded file.",
+        ),
     ] = True,
     verify_size: Annotated[
         bool,
-        typer.Option(help="Whether to check the size of each downloaded file."),
+        typer.Option(
+            "--verify_size", help="Whether to check the size of each downloaded file."
+        ),
     ] = True,
     max_retries: Annotated[
         int,
         typer.Option(
-            help="Try the specified number of times to download a file before failing."
+            "--max_retries",
+            help="Try the specified number of times to download a file before failing.",
         ),
     ] = 5,
     max_concurrent_downloads: Annotated[
         int,
-        typer.Option(help="The maximum number of downloads to run in parallel."),
+        typer.Option(
+            "--max_concurrent_downloads",
+            help="The maximum number of downloads to run in parallel.",
+        ),
     ] = 5,
 ) -> None:
     """Download datasets from OpenNeuro."""

--- a/src/openneuro/_cli.py
+++ b/src/openneuro/_cli.py
@@ -19,9 +19,7 @@ def download_cli(
     ] = None,
     target_dir: Annotated[
         Optional[str],
-        typer.Option(
-            help="The directory to download to.", show_default=False
-        ),
+        typer.Option(help="The directory to download to.", show_default=False),
     ] = None,
     include: Annotated[
         Optional[str],
@@ -47,9 +45,7 @@ def download_cli(
     ] = True,
     verify_size: Annotated[
         bool,
-        typer.Option(
-            help="Whether to check the size of each downloaded file."
-        ),
+        typer.Option(help="Whether to check the size of each downloaded file."),
     ] = True,
     max_retries: Annotated[
         int,

--- a/src/openneuro/_cli.py
+++ b/src/openneuro/_cli.py
@@ -20,7 +20,7 @@ def download_cli(
     target_dir: Annotated[
         Optional[str],
         typer.Option(
-            "--target_dir", help="The directory to download to.", show_default=False
+            help="The directory to download to.", show_default=False
         ),
     ] = None,
     include: Annotated[
@@ -42,27 +42,24 @@ def download_cli(
     verify_hash: Annotated[
         bool,
         typer.Option(
-            "--verify_hash",
             help="Whether to check the SHA256 hash of each downloaded file.",
         ),
     ] = True,
     verify_size: Annotated[
         bool,
         typer.Option(
-            "--verify_size", help="Whether to check the size of each downloaded file."
+            help="Whether to check the size of each downloaded file."
         ),
     ] = True,
     max_retries: Annotated[
         int,
         typer.Option(
-            "--max_retries",
             help="Try the specified number of times to download a file before failing.",
         ),
     ] = 5,
     max_concurrent_downloads: Annotated[
         int,
         typer.Option(
-            "--max_concurrent_downloads",
             help="The maximum number of downloads to run in parallel.",
         ),
     ] = 5,

--- a/src/openneuro/tests/test_download.py
+++ b/src/openneuro/tests/test_download.py
@@ -2,9 +2,10 @@ import json
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 import openneuro
 import openneuro._config
-import pytest
 from openneuro import download
 
 dataset_id_aws = "ds000246"

--- a/src/openneuro/tests/test_download.py
+++ b/src/openneuro/tests/test_download.py
@@ -2,10 +2,9 @@ import json
 from pathlib import Path
 from unittest import mock
 
-import pytest
-
 import openneuro
 import openneuro._config
+import pytest
 from openneuro import download
 
 dataset_id_aws = "ds000246"


### PR DESCRIPTION
Omit printing some default values on the help screen.

