### PR TITLE
Change the `typer[all]` dependency to `typer-slim[standard]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "httpx >= 0.15",
   "requests",
   "tqdm",
-  "typer[all]",
+  "typer-slim[standard]",
   "aiofiles",
   "sgqlc",
   "platformdirs",


### PR DESCRIPTION
In 0.12.1, Typer was significantly reorganized.

- `typer-slim` is the library (for `import typer`)
- `typer-slim[standard]` adds optional dependencies (currently `rich` and `shellingham`, basically equivalent to the old `typer[all]`)
- `typer-cli` is the `typer` command-line tool
- `typer` is now basically a metapackage that brings in *all of the above*, and it no longer has an `all` extra

Pip will warn about this and proceed,

```
WARNING: typer 0.12.1 does not provide the extra 'all'
```

but there are other tools that will fail hard when asked to resolve a (now) nonexistent extra.

Since this project doesn’t need the `typer` command-line tool, it looks like changing the dependency to `typer-slim[standard]` is the best way forward.

See https://typer.tiangolo.com/release-notes/#0121 and https://github.com/tiangolo/typer/discussions/785 for further discussion and details.

----

I am the maintainer of the [`python-typer`](https://src.fedoraproject.org/rpms/python-typer) package in Fedora Linux, and I’m trying to get everything that depends on it to be compatible with this reorganization so I can update it.

I tested this PR by `pip install -e .[tests]` in a virtualenv, followed by running `python -m pytest` and trying a few of the [Basic usage – command line interface](https://github.com/hoechenberger/openneuro-py?tab=readme-ov-file#basic-usage--command-line-interface) examples and confirming that the output was still “pretty,” with box-drawing, colors, and so on.