### PR TITLE
In the "publish" workflow, check out with `fetch-depth=0`

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
Just to be sure we can always derive the correct version number dynamically.

x-ref #160

cc @cbrnr @larsoner 