### PR TITLE
ENH: More verbose error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 build/
 .vscode/
 .DS_Store
+/*.egg-info
+/.hypothesis/


### PR DESCRIPTION
I always forget how to submit bug reports to OpenNeuro. So to save myself some effort next time, turn this error message:

    E   RuntimeError: Error 404 when trying to download /home/larsoner/mne_data/ds000248/derivatives/freesurfer/subjects/fsaverage/label/Yeo_Brainmap_fsaverage_README from https://s3.amazonaws.com/openneuro.org/ds000248/derivatives/freesurfer/subjects/fsaverage/label/Yeo_Brainmap_fsaverage_README?versionId=WuMze1X4S_cLoRCbEs5IpCIOJMe2VT41

Into this:

    RuntimeError: Error 404 when trying to download /home/larsoner/mne_data/ds000248/derivatives/freesurfer/subjects/fsaverage/label/lh.BA1_exvivo.label. If this is unexpected:
    E   
    E   1. Navigate to https://openneuro.org/crn/graphql
    E   2. Enter and run the operation: query { snapshot(datasetId: "ds000248" , tag: "1.2.4" ) { id files(tree: "4051a693617af344e8498593d4bf4cb258f341bd" ) { filename urls size directory id } } }
    E   3. In the Response, try to manually download the "urls" for "Yeo_Brainmap_fsaverage_README", which should contain https://s3.amazonaws.com/openneuro.org/ds000248/derivatives/freesurfer/subjects/fsaverage/label/Yeo_Brainmap_fsaverage_README?versionId=WuMze1X4S_cLoRCbEs5IpCIOJMe2VT41
    E   
    E   If the download fails, open a GitHub issue like https://github.com/OpenNeuroOrg/openneuro/issues/3145

And used it to open https://github.com/OpenNeuroOrg/openneuro/issues/3145
